### PR TITLE
Fixing Typo on "enumrate" vs "enumerate"

### DIFF
--- a/kmeans.py.ipynb
+++ b/kmeans.py.ipynb
@@ -178,7 +178,7 @@
     "        iteration += 1\n",
     "        norm = dist_method(prototypes, prototypes_old)\n",
     "        #for each instance in the dataset\n",
-    "        for index_instance, instance in enumrate(dataset):\n",
+    "        for index_instance, instance in enumerate(dataset):\n",
     "            #define a distance vector of size k\n",
     "            dist_vec = np.zeros((k,1))\n",
     "            #for each centroid\n",


### PR DESCRIPTION
It gave the error: Name "enumrate" is not defined